### PR TITLE
add interfaces to dynamically adjust video size

### DIFF
--- a/include/f1x/openauto/autoapp/Projection/InputDevice.hpp
+++ b/include/f1x/openauto/autoapp/Projection/InputDevice.hpp
@@ -45,6 +45,7 @@ public:
     bool eventFilter(QObject* obj, QEvent* event) override;
     bool hasTouchscreen() const override;
     QRect getTouchscreenGeometry() const override;
+    void setTouchscreenGeometry(QRect& touchscreenGeometry);
 
 private:
     void setVideoGeometry();

--- a/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
@@ -62,6 +62,7 @@ public:
     void write(uint64_t timestamp, const aasdk::common::DataConstBuffer& buffer) override;
     void stop() override;
     void setOpacity(OMX_U32 alpha);
+    void setDestRect(DestRect destRect);
 
 private:
     bool createComponents();

--- a/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
@@ -55,7 +55,7 @@ struct DestRect
 class OMXVideoOutput: public VideoOutput
 {
 public:
-    OMXVideoOutput(configuration::IConfiguration::Pointer configuration, OMX_U32 alpha=255, DestRect destRect=DestRect(), std::function<void(bool)> activeCallback=nullptr);
+    OMXVideoOutput(configuration::IConfiguration::Pointer configuration, DestRect destRect=DestRect(), std::function<void(bool)> activeCallback=nullptr);
 
     bool open() override;
     bool init() override;

--- a/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
@@ -55,7 +55,7 @@ struct DestRect
 class OMXVideoOutput: public VideoOutput
 {
 public:
-    OMXVideoOutput(configuration::IConfiguration::Pointer configuration, DestRect destRect=DestRect(), std::function<void(bool)> activeCallback=nullptr);
+    OMXVideoOutput(configuration::IConfiguration::Pointer configuration, OMX_U32 alpha=255, DestRect destRect=DestRect(), std::function<void(bool)> activeCallback=nullptr);
 
     bool open() override;
     bool init() override;

--- a/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
@@ -61,8 +61,8 @@ public:
     bool init() override;
     void write(uint64_t timestamp, const aasdk::common::DataConstBuffer& buffer) override;
     void stop() override;
-    void setOpacity(OMX_U32 alpha, bool skipUpdate=false);
-    void setDestRect(DestRect destRect, bool skipUpdate=false);
+    void setOpacity(OMX_U32 alpha);
+    void setDestRect(DestRect destRect);
 
 private:
     bool createComponents();

--- a/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp
@@ -61,8 +61,8 @@ public:
     bool init() override;
     void write(uint64_t timestamp, const aasdk::common::DataConstBuffer& buffer) override;
     void stop() override;
-    void setOpacity(OMX_U32 alpha);
-    void setDestRect(DestRect destRect);
+    void setOpacity(OMX_U32 alpha, bool skipUpdate=false);
+    void setDestRect(DestRect destRect, bool skipUpdate=false);
 
 private:
     bool createComponents();

--- a/include/f1x/openauto/autoapp/Projection/QtVideoOutput.hpp
+++ b/include/f1x/openauto/autoapp/Projection/QtVideoOutput.hpp
@@ -43,6 +43,7 @@ public:
     bool init() override;
     void write(uint64_t timestamp, const aasdk::common::DataConstBuffer& buffer) override;
     void stop() override;
+    void resize();
 
 signals:
     void startPlayback();

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -20,7 +20,9 @@
 
 #include <f1x/openauto/autoapp/Service/IServiceFactory.hpp>
 #include <f1x/openauto/autoapp/Configuration/IConfiguration.hpp>
+#include <f1x/openauto/autoapp/Projection/InputDevice.hpp>
 #include <f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp>
+#include <f1x/openauto/autoapp/Projection/QtVideoOutput.hpp>
 
 namespace f1x
 {
@@ -37,6 +39,7 @@ public:
     ServiceFactory(boost::asio::io_service& ioService, configuration::IConfiguration::Pointer configuration, QWidget* activeArea=nullptr, std::function<void(bool)> activeCallback=nullptr);
     ServiceList create(aasdk::messenger::IMessenger::Pointer messenger) override;
     void setOpacity(unsigned int alpha);
+    void resize();
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);
@@ -53,8 +56,11 @@ private:
     QWidget* activeArea_;
     QRect screenGeometry_;
     std::function<void(bool)> activeCallback_;
+    std::shared_ptr<projection::InputDevice> inputDevice_;
 #ifdef USE_OMX
     std::shared_ptr<projection::OMXVideoOutput> omxVideoOutput_;
+#else
+    projection::QtVideoOutput *qtVideoOutput_;
 #endif
 };
 

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -40,7 +40,6 @@ public:
     ServiceList create(aasdk::messenger::IMessenger::Pointer messenger) override;
     void setOpacity(unsigned int alpha);
     void resize();
-    void syncVideoOutput();
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -39,7 +39,7 @@ public:
     ServiceFactory(boost::asio::io_service& ioService, configuration::IConfiguration::Pointer configuration, QWidget* activeArea=nullptr, std::function<void(bool)> activeCallback=nullptr);
     ServiceList create(aasdk::messenger::IMessenger::Pointer messenger) override;
     void setOpacity(unsigned int alpha);
-    void resize();
+    void resize(bool skipUpdate=false);
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -39,7 +39,8 @@ public:
     ServiceFactory(boost::asio::io_service& ioService, configuration::IConfiguration::Pointer configuration, QWidget* activeArea=nullptr, std::function<void(bool)> activeCallback=nullptr);
     ServiceList create(aasdk::messenger::IMessenger::Pointer messenger) override;
     void setOpacity(unsigned int alpha);
-    void resize(bool skipUpdate=false);
+    void resize();
+    void syncVideoOutput();
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -44,6 +44,7 @@ public:
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);
+    static unsigned int activeAreaAlpha(QWidget *activeArea);
 #endif
 
 private:

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -44,7 +44,6 @@ public:
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);
-    static unsigned int activeAreaAlpha(QWidget *activeArea);
 #endif
 
 private:

--- a/src/autoapp/Projection/InputDevice.cpp
+++ b/src/autoapp/Projection/InputDevice.cpp
@@ -225,6 +225,11 @@ QRect InputDevice::getTouchscreenGeometry() const
     return touchscreenGeometry_;
 }
 
+void InputDevice::setTouchscreenGeometry(QRect& touchscreenGeometry)
+{
+    touchscreenGeometry_ = touchscreenGeometry;
+}
+
 IInputDevice::ButtonCodes InputDevice::getSupportedButtonCodes() const
 {
     return configuration_->getButtonCodes();

--- a/src/autoapp/Projection/OMXVideoOutput.cpp
+++ b/src/autoapp/Projection/OMXVideoOutput.cpp
@@ -249,14 +249,18 @@ void OMXVideoOutput::setOpacity(OMX_U32 alpha)
     alpha_ = alpha;
     if(isActive_)
     {
-        OMX_CONFIG_DISPLAYREGIONTYPE displayRegion;
-        displayRegion.nSize = sizeof(OMX_CONFIG_DISPLAYREGIONTYPE);
-        displayRegion.nVersion.nVersion = OMX_VERSION;
-        displayRegion.nPortIndex = 90;
-        displayRegion.alpha = alpha_;
-        displayRegion.set = static_cast<OMX_DISPLAYSETTYPE >(OMX_DISPLAY_SET_ALPHA);
+        this->setupDisplayRegion();
+    }
+}
 
-        OMX_SetConfig(ilclient_get_handle(components_[VideoComponent::RENDERER]), OMX_IndexConfigDisplayRegion, &displayRegion) == OMX_ErrorNone;
+void OMXVideoOutput::setDestRect(DestRect destRect)
+{
+    std::lock_guard<decltype(mutex_)> lock(mutex_);
+
+    destRect_ = destRect;
+    if(isActive_)
+    {
+        this->setupDisplayRegion();
     }
 }
 

--- a/src/autoapp/Projection/OMXVideoOutput.cpp
+++ b/src/autoapp/Projection/OMXVideoOutput.cpp
@@ -60,13 +60,13 @@ namespace VideoComponent
     static constexpr uint32_t SCHEDULER = 3;
 }
 
-OMXVideoOutput::OMXVideoOutput(configuration::IConfiguration::Pointer configuration, OMX_U32 alpha, DestRect destRect, std::function<void(bool)> activeCallback)
+OMXVideoOutput::OMXVideoOutput(configuration::IConfiguration::Pointer configuration, DestRect destRect, std::function<void(bool)> activeCallback)
     : VideoOutput(std::move(configuration))
     , isActive_(false)
     , portSettingsChanged_(false)
     , client_(nullptr)
     , destRect_(destRect)
-    , alpha_(alpha)
+    , alpha_(255)
     , activeCallback_(activeCallback)
 {
     memset(components_, 0, sizeof(components_));

--- a/src/autoapp/Projection/OMXVideoOutput.cpp
+++ b/src/autoapp/Projection/OMXVideoOutput.cpp
@@ -242,23 +242,23 @@ void OMXVideoOutput::stop()
     }
 }
 
-void OMXVideoOutput::setOpacity(OMX_U32 alpha, bool skipUpdate)
+void OMXVideoOutput::setOpacity(OMX_U32 alpha)
 {
     std::lock_guard<decltype(mutex_)> lock(mutex_);
 
     alpha_ = alpha;
-    if(isActive_ && !skipUpdate)
+    if(isActive_)
     {
         this->setupDisplayRegion();
     }
 }
 
-void OMXVideoOutput::setDestRect(DestRect destRect, bool skipUpdate)
+void OMXVideoOutput::setDestRect(DestRect destRect)
 {
     std::lock_guard<decltype(mutex_)> lock(mutex_);
 
     destRect_ = destRect;
-    if(isActive_ && !skipUpdate)
+    if(isActive_)
     {
         this->setupDisplayRegion();
     }

--- a/src/autoapp/Projection/OMXVideoOutput.cpp
+++ b/src/autoapp/Projection/OMXVideoOutput.cpp
@@ -114,9 +114,9 @@ bool OMXVideoOutput::open()
     }
 
     isActive_ = true;
-    if(this->activeCallback_ != nullptr)
+    if(activeCallback_ != nullptr)
     {
-        this->activeCallback_(isActive_);
+        activeCallback_(isActive_);
     }
     return true;
 }
@@ -219,9 +219,9 @@ void OMXVideoOutput::stop()
     if(isActive_)
     {
         isActive_ = false;
-        if(this->activeCallback_ != nullptr)
+        if(activeCallback_ != nullptr)
         {
-            this->activeCallback_(isActive_);
+            activeCallback_(isActive_);
         }
 
         ilclient_disable_tunnel(&tunnels_[0]);
@@ -242,23 +242,23 @@ void OMXVideoOutput::stop()
     }
 }
 
-void OMXVideoOutput::setOpacity(OMX_U32 alpha)
+void OMXVideoOutput::setOpacity(OMX_U32 alpha, bool skipUpdate)
 {
     std::lock_guard<decltype(mutex_)> lock(mutex_);
 
     alpha_ = alpha;
-    if(isActive_)
+    if(isActive_ && !skipUpdate)
     {
         this->setupDisplayRegion();
     }
 }
 
-void OMXVideoOutput::setDestRect(DestRect destRect)
+void OMXVideoOutput::setDestRect(DestRect destRect, bool skipUpdate)
 {
     std::lock_guard<decltype(mutex_)> lock(mutex_);
 
     destRect_ = destRect;
-    if(isActive_)
+    if(isActive_ && !skipUpdate)
     {
         this->setupDisplayRegion();
     }

--- a/src/autoapp/Projection/QtVideoOutput.cpp
+++ b/src/autoapp/Projection/QtVideoOutput.cpp
@@ -69,6 +69,11 @@ void QtVideoOutput::write(uint64_t, const aasdk::common::DataConstBuffer& buffer
     videoBuffer_.write(reinterpret_cast<const char*>(buffer.cdata), buffer.size);
 }
 
+void QtVideoOutput::resize()
+{
+    if (videoWidget_ != nullptr && videoContainer_ != nullptr) videoWidget_->resize(videoContainer_->size());
+}
+
 void QtVideoOutput::onStartPlayback()
 {
     if (videoContainer_ == nullptr)

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -56,7 +56,7 @@ ServiceFactory::ServiceFactory(boost::asio::io_service& ioService, configuration
     , screenGeometry_(this->mapActiveAreaToGlobal(activeArea_))
     , activeCallback_(activeCallback)
 #ifdef USE_OMX
-    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->activeAreaAlpha(activeArea_), this->QRectToDestRect(screenGeometry_), activeCallback_))
+    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_))
 #endif
 {
 
@@ -200,11 +200,6 @@ QRect ServiceFactory::mapActiveAreaToGlobal(QWidget* activeArea)
 projection::DestRect ServiceFactory::QRectToDestRect(QRect rect)
 {
     return projection::DestRect(rect.x(), rect.y(), rect.width(), rect.height());
-}
-
-unsigned int ServiceFactory::activeAreaAlpha(QWidget *activeArea)
-{
-    return (activeArea != nullptr) ? activeArea->windowOpacity() : 255;
 }
 #endif
 

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -56,7 +56,7 @@ ServiceFactory::ServiceFactory(boost::asio::io_service& ioService, configuration
     , screenGeometry_(this->mapActiveAreaToGlobal(activeArea_))
     , activeCallback_(activeCallback)
 #ifdef USE_OMX
-    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_))
+    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->activeAreaAlpha(activeArea_), this->QRectToDestRect(screenGeometry_), activeCallback_))
 #endif
 {
 
@@ -200,6 +200,11 @@ QRect ServiceFactory::mapActiveAreaToGlobal(QWidget* activeArea)
 projection::DestRect ServiceFactory::QRectToDestRect(QRect rect)
 {
     return projection::DestRect(rect.x(), rect.y(), rect.width(), rect.height());
+}
+
+unsigned int ServiceFactory::activeAreaAlpha(QWidget *activeArea)
+{
+    return (activeArea != nullptr) ? activeArea->windowOpacity() : 255;
 }
 #endif
 

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -55,9 +55,6 @@ ServiceFactory::ServiceFactory(boost::asio::io_service& ioService, configuration
     , activeArea_(activeArea)
     , screenGeometry_(this->mapActiveAreaToGlobal(activeArea_))
     , activeCallback_(activeCallback)
-#ifdef USE_OMX
-    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_))
-#endif
 {
 
 }
@@ -80,10 +77,15 @@ ServiceList ServiceFactory::create(aasdk::messenger::IMessenger::Pointer messeng
 IService::Pointer ServiceFactory::createVideoService(aasdk::messenger::IMessenger::Pointer messenger)
 {
 #ifdef USE_OMX
+    omxVideoOutput_ = std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_);
     auto videoOutput(omxVideoOutput_);
 #else
-    auto qtVideoOutput = new projection::QtVideoOutput(configuration_, activeArea_);
-    projection::IVideoOutput::Pointer videoOutput(qtVideoOutput, std::bind(&QObject::deleteLater, std::placeholders::_1));
+    qtVideoOutput_ = new projection::QtVideoOutput(configuration_, activeArea_);
+    if (activeCallback_ != nullptr) {
+        QObject::connect(qtVideoOutput_, &projection::QtVideoOutput::startPlayback, [callback = activeCallback_]() { callback(true); });
+        QObject::connect(qtVideoOutput_, &projection::QtVideoOutput::stopPlayback, [callback = activeCallback_]() { callback(false); });
+    }
+    projection::IVideoOutput::Pointer videoOutput(qtVideoOutput_, std::bind(&QObject::deleteLater, std::placeholders::_1));
 #endif
     return std::make_shared<VideoService>(ioService_, messenger, std::move(videoOutput));
 }
@@ -128,9 +130,9 @@ IService::Pointer ServiceFactory::createInputService(aasdk::messenger::IMessenge
     }
 
     QObject* inputObject = activeArea_ == nullptr ? qobject_cast<QObject*>(QApplication::instance()) : qobject_cast<QObject*>(activeArea_);
-    projection::IInputDevice::Pointer inputDevice(std::make_shared<projection::InputDevice>(*inputObject, configuration_, std::move(screenGeometry_), std::move(videoGeometry)));
+    inputDevice_ = std::make_shared<projection::InputDevice>(*inputObject, configuration_, std::move(screenGeometry_), std::move(videoGeometry));
 
-    return std::make_shared<InputService>(ioService_, messenger, std::move(inputDevice));
+    return std::make_shared<InputService>(ioService_, messenger, std::move(projection::IInputDevice::Pointer(inputDevice_)));
 }
 
 void ServiceFactory::createAudioServices(ServiceList& serviceList, aasdk::messenger::IMessenger::Pointer messenger)
@@ -163,7 +165,18 @@ void ServiceFactory::createAudioServices(ServiceList& serviceList, aasdk::messen
 void ServiceFactory::setOpacity(unsigned int alpha)
 {
 #ifdef USE_OMX
-    omxVideoOutput_->setOpacity(alpha);
+    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setOpacity(alpha);
+#endif
+}
+
+void ServiceFactory::resize()
+{
+    screenGeometry_ = this->mapActiveAreaToGlobal(activeArea_);
+    if (inputDevice_ != nullptr) inputDevice_->setTouchscreenGeometry(screenGeometry_);
+#ifdef USE_OMX
+    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect();
+#else
+    if (qtVideoOutput_ != nullptr) qtVideoOutput_->resize();
 #endif
 }
 

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -171,12 +171,12 @@ void ServiceFactory::setOpacity(unsigned int alpha)
 #endif
 }
 
-void ServiceFactory::resize(bool skipUpdate)
+void ServiceFactory::resize()
 {
     screenGeometry_ = this->mapActiveAreaToGlobal(activeArea_);
     if (inputDevice_ != nullptr) inputDevice_->setTouchscreenGeometry(screenGeometry_);
 #ifdef USE_OMX
-    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect(this->QRectToDestRect(screenGeometry_), skipUpdate);
+    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect(this->QRectToDestRect(screenGeometry_));
 #else
     if (qtVideoOutput_ != nullptr) qtVideoOutput_->resize();
 #endif

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -55,6 +55,9 @@ ServiceFactory::ServiceFactory(boost::asio::io_service& ioService, configuration
     , activeArea_(activeArea)
     , screenGeometry_(this->mapActiveAreaToGlobal(activeArea_))
     , activeCallback_(activeCallback)
+#ifdef USE_OMX
+    , omxVideoOutput_(std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_))
+#endif
 {
 
 }
@@ -77,7 +80,6 @@ ServiceList ServiceFactory::create(aasdk::messenger::IMessenger::Pointer messeng
 IService::Pointer ServiceFactory::createVideoService(aasdk::messenger::IMessenger::Pointer messenger)
 {
 #ifdef USE_OMX
-    omxVideoOutput_ = std::make_shared<projection::OMXVideoOutput>(configuration_, this->QRectToDestRect(screenGeometry_), activeCallback_);
     auto videoOutput(omxVideoOutput_);
 #else
     qtVideoOutput_ = new projection::QtVideoOutput(configuration_, activeArea_);
@@ -174,7 +176,7 @@ void ServiceFactory::resize()
     screenGeometry_ = this->mapActiveAreaToGlobal(activeArea_);
     if (inputDevice_ != nullptr) inputDevice_->setTouchscreenGeometry(screenGeometry_);
 #ifdef USE_OMX
-    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect();
+    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect(this->QRectToDestRect(screenGeometry_));
 #else
     if (qtVideoOutput_ != nullptr) qtVideoOutput_->resize();
 #endif

--- a/src/autoapp/Service/ServiceFactory.cpp
+++ b/src/autoapp/Service/ServiceFactory.cpp
@@ -171,12 +171,12 @@ void ServiceFactory::setOpacity(unsigned int alpha)
 #endif
 }
 
-void ServiceFactory::resize()
+void ServiceFactory::resize(bool skipUpdate)
 {
     screenGeometry_ = this->mapActiveAreaToGlobal(activeArea_);
     if (inputDevice_ != nullptr) inputDevice_->setTouchscreenGeometry(screenGeometry_);
 #ifdef USE_OMX
-    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect(this->QRectToDestRect(screenGeometry_));
+    if (omxVideoOutput_ != nullptr) omxVideoOutput_->setDestRect(this->QRectToDestRect(screenGeometry_), skipUpdate);
 #else
     if (qtVideoOutput_ != nullptr) qtVideoOutput_->resize();
 #endif


### PR DESCRIPTION
Adding the interfaces to support toggling OpenAuto into fullscreen mode.

With all these additions, I realized it would probably make sense to move these changes to the VideoService class and minimize the amount `#ifdef USE_OMX` directives I use... something to consider for a cleanup feature? (just to write my thoughts down, the cleanup feature will also include debugging the _black bars_ around Qt Video Widget which screws with the touch area, QParent apparently being in a different thread, "paintEngine should no longer be called" and QBasicTimer messages, double free for I think the configuration class, better callback usage for omx player, among other things)