### PR TITLE
add interface to allow for night mode control

### DIFF
--- a/include/f1x/openauto/autoapp/Service/SensorService.hpp
+++ b/include/f1x/openauto/autoapp/Service/SensorService.hpp
@@ -33,7 +33,7 @@ namespace service
 class SensorService: public aasdk::channel::sensor::ISensorServiceChannelEventHandler, public IService, public std::enable_shared_from_this<SensorService>
 {
 public:
-    SensorService(boost::asio::io_service& ioService, aasdk::messenger::IMessenger::Pointer messenger);
+    SensorService(boost::asio::io_service& ioService, aasdk::messenger::IMessenger::Pointer messenger, bool nightMode = false);
 
     void start() override;
     void stop() override;
@@ -41,6 +41,7 @@ public:
     void onChannelOpenRequest(const aasdk::proto::messages::ChannelOpenRequest& request) override;
     void onSensorStartRequest(const aasdk::proto::messages::SensorStartRequestMessage& request) override;
     void onChannelError(const aasdk::error::Error& e) override;
+    void setNightMode(bool nightMode);
 
 private:
     using std::enable_shared_from_this<SensorService>::shared_from_this;
@@ -49,6 +50,7 @@ private:
 
     boost::asio::io_service::strand strand_;
     aasdk::channel::sensor::SensorServiceChannel::Pointer channel_;
+    bool nightMode_;
 };
 
 }

--- a/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
+++ b/include/f1x/openauto/autoapp/Service/ServiceFactory.hpp
@@ -23,6 +23,7 @@
 #include <f1x/openauto/autoapp/Projection/InputDevice.hpp>
 #include <f1x/openauto/autoapp/Projection/OMXVideoOutput.hpp>
 #include <f1x/openauto/autoapp/Projection/QtVideoOutput.hpp>
+#include <f1x/openauto/autoapp/Service/SensorService.hpp>
 
 namespace f1x
 {
@@ -36,10 +37,11 @@ namespace service
 class ServiceFactory: public IServiceFactory
 {
 public:
-    ServiceFactory(boost::asio::io_service& ioService, configuration::IConfiguration::Pointer configuration, QWidget* activeArea=nullptr, std::function<void(bool)> activeCallback=nullptr);
+    ServiceFactory(boost::asio::io_service& ioService, configuration::IConfiguration::Pointer configuration, QWidget* activeArea=nullptr, std::function<void(bool)> activeCallback=nullptr, bool nightMode = false);
     ServiceList create(aasdk::messenger::IMessenger::Pointer messenger) override;
     void setOpacity(unsigned int alpha);
     void resize();
+    void setNightMode(bool nightMode);
     static QRect mapActiveAreaToGlobal(QWidget* activeArea);
 #ifdef USE_OMX
     static projection::DestRect QRectToDestRect(QRect rect);
@@ -62,6 +64,8 @@ private:
 #else
     projection::QtVideoOutput *qtVideoOutput_;
 #endif
+    bool nightMode_;
+    std::shared_ptr<SensorService> sensorService_;
 };
 
 }


### PR DESCRIPTION
Simple and straightforward. Title says it all.

Was planning on adding an interface to get night mode, but since it doesn't seem like there is an indication for when it actually changes, it would really only be useful at startup (it is something that can always be added later tho).